### PR TITLE
qemu 3.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
+dist: xenial
 sudo: required
 services: docker
 language: bash
 env:
     global:
-        - QEMU_VER=v2.12.0
+        - QEMU_VER=v3.1.0-3
         - DOCKER_REPO=multiarch/debian-debootstrap
     matrix:
         - ARCH=amd64 INCLUDE=wget QEMU_ARCH=x86_64 SUITE=jessie UNAME_ARCH=x86_64 VERSION=jessie


### PR DESCRIPTION
Same with https://github.com/multiarch/ubuntu-debootstrap/pull/25
`dist: xenial` is to use Ubuntu xenial that is the latest version in Travis. The default is trusty. It's old.
 